### PR TITLE
More Efficent Module Level Extraction

### DIFF
--- a/Poco/CraftingTable/JsonCraftingTable.cs
+++ b/Poco/CraftingTable/JsonCraftingTable.cs
@@ -16,9 +16,9 @@ namespace Eco.Plugins.EcoLiveDataExporter.Poco
         //public List<string> Benefits { get; set; }
         public int ModuleLevel { get; set; }
 
-        public float genericMultiplier { get; set; } = 1;
+        public float GenericMultiplier { get; set; } = 1;
 
-        public float skillMultiplier { get; set; } = 1;
+        public float SkillMultiplier { get; set; } = 1;
 
         public JsonCraftingTable (CraftingComponent component)
         {
@@ -41,13 +41,13 @@ namespace Eco.Plugins.EcoLiveDataExporter.Poco
             EfficiencyModule efficencyModule = component?.ResourceEfficiencyModule as EfficiencyModule;
             if (efficencyModule != null)
             {
-                genericMultiplier = efficencyModule.GenericMultiplier;
+                GenericMultiplier = efficencyModule.GenericMultiplier;
                 // On Unspecific Modules, like BU1-BU4, this is always 1, so we set it to the minimum of both.
-                skillMultiplier = Math.Min(efficencyModule.SkillMultiplier, efficencyModule.GenericMultiplier);
+                SkillMultiplier = Math.Min(efficencyModule.SkillMultiplier, efficencyModule.GenericMultiplier);
 
                 float[] multiplierByLevel = new float[] { 0.9f, 0.75f, 0.6f, 0.55f, 0.5f };
 
-                ModuleLevel = Array.FindIndex(multiplierByLevel, (modifier) => modifier == skillMultiplier) + 1;
+                ModuleLevel = Array.FindIndex(multiplierByLevel, (modifier) => modifier == SkillMultiplier) + 1;
             }
             else
             {

--- a/Poco/CraftingTable/JsonCraftingTable.cs
+++ b/Poco/CraftingTable/JsonCraftingTable.cs
@@ -1,5 +1,6 @@
 ﻿using Eco.Gameplay.Components;
-
+using Eco.Gameplay.Modules;
+using Eco.Plugins.EcoLiveDataExporter.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,32 +15,43 @@ namespace Eco.Plugins.EcoLiveDataExporter.Poco
         public string OwnerName { get; set; }
         //public List<string> Benefits { get; set; }
         public int ModuleLevel { get; set; }
+
+        public float genericMultiplier { get; set; } = 1;
+
+        public float skillMultiplier { get; set; } = 1;
+
         public JsonCraftingTable (CraftingComponent component)
         {
             TableName = component?.Parent?.DisplayName;
             ResourceEfficiencyModule = component?.ResourceEfficiencyModule?.DisplayName;
+            
             OwnerName = component?.Parent?.Owners?.Name;
             ModuleLevel = 0;
-            //Benefits = component?.ResourceEfficiencyModule?.Benefits.Select(t => t.NotTranslated).ToList();
 
-            //Get the 25% string out of the string "Decreases resource cost for the table work orders by <style=\"Positive\">25%</style>."
-            //Level 5 is currently never fetched, since it will not work for all recipes in the table
-            var ResourceBenefitString = component?.ResourceEfficiencyModule?.Benefits?.Select(t => t.NotTranslated).Where(t => t.IndexOf("Decreases resource cost for the table work orders by") >= 0).FirstOrDefault();
-            if (ResourceBenefitString == null) { return; }
-            if (ResourceBenefitString.IndexOf("10%") > 0)
+            if (null == (component?.ResourceEfficiencyModule))
             {
-                ModuleLevel = 1;
-            } else if (ResourceBenefitString.IndexOf("25%") > 0)
-            {
-                ModuleLevel = 2;
+                return;
             }
-            else if (ResourceBenefitString.IndexOf("40%") > 0)
+
+            /**
+            * Typecast to EfficiencyModule, will be null when not possible.
+            * The MetaData states, that the return Type is PluginModule. My Guess is, that this will always be an EfficencyModule and the Type is just there for future? changes.
+            * All Upgrades i looked into in `__core__\AutoGen\PluginModule` are Implemented as EfficiencyModule.
+            */
+            EfficiencyModule efficencyModule = component?.ResourceEfficiencyModule as EfficiencyModule;
+            if (efficencyModule != null)
             {
-                ModuleLevel = 3;
+                genericMultiplier = efficencyModule.GenericMultiplier;
+                // On Unspecific Modules, like BU1-BU4, this is always 1, so we set it to the minimum of both.
+                skillMultiplier = Math.Min(efficencyModule.SkillMultiplier, efficencyModule.GenericMultiplier);
+
+                float[] multiplierByLevel = new float[] { 0.9f, 0.75f, 0.6f, 0.55f, 0.5f };
+
+                ModuleLevel = Array.FindIndex(multiplierByLevel, (modifier) => modifier == skillMultiplier) + 1;
             }
-            else if (ResourceBenefitString.IndexOf("45%") > 0)
+            else
             {
-                ModuleLevel = 4;
+                Logger.Info("PluginModule is not typeOf EfficiencyModule: " + component?.Name);
             }
         }
     }


### PR DESCRIPTION
I put some research in the ResourceEfficiencyModule. It looks like, the Modules will always be Type of `EfficiencyModule`.
All Modules in  `mods/__core__/AutoGen/PluginModule` are Implemented as EfficiencyModule. This type contains the Attributes `GenericMultiplier` and `SkillMultiplier`, which we can use to extract the Plugin Level. This should be much more reliable then the previous extraction from the Description Text.